### PR TITLE
Add export option to ClassURLWriter

### DIFF
--- a/render_static/url_tree.py
+++ b/render_static/url_tree.py
@@ -805,6 +805,10 @@ class ClassURLWriter(URLTreeVisitor):
         * *raise_on_not_found*
             Raise a TypeError if no reversal for a url pattern is found,
             default: True
+        * *export_class*
+            The generated JavaScript file will include an export statement
+            for the generated class.
+            default: False
 
     :param kwargs: Set of configuration parameters, see also `URLTreeVisitor` params
     """

--- a/render_static/url_tree.py
+++ b/render_static/url_tree.py
@@ -811,11 +811,13 @@ class ClassURLWriter(URLTreeVisitor):
 
     class_name_ = 'URLResolver'
     raise_on_not_found_ = True
+    export_class_ = False
 
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
         self.class_name_ = kwargs.pop('class_name', self.class_name_)
         self.raise_on_not_found_ = kwargs.pop('raise_on_not_found', self.raise_on_not_found_)
+        self.export_class_ = kwargs.pop('export_class', self.export_class_)
 
     def start_visitation(self) -> Generator[str, None, None]:  # pylint: disable=R0915
         """
@@ -971,6 +973,12 @@ class ClassURLWriter(URLTreeVisitor):
         yield '}'
         self.outdent()
         yield '};'
+
+        if self.export_class_:
+            if self.es5_:
+                yield f'exports.{self.class_name_} = {self.class_name_};'
+            else:
+                yield f'export {{ {self.class_name_} }};'
 
     def enter_namespace(self, namespace: str) -> Generator[str, None, None]:
         """


### PR DESCRIPTION
Hi, really nice library! I'm using it to generate a JS class for a client that lives outside of my Django codebase. So it would be ideal if the class that gets generated also gets exported. This PR adds that in in the simplest way I could think of. Not 100% sure what the best way to do exports is in es5, please let me know if there's a better option. 

Also happy to add tests if you'd like this feature merged :smile: 